### PR TITLE
Demonstrates that max-hits can be specified with values greater than a short size

### DIFF
--- a/pybwa/libbwaindex.pxd
+++ b/pybwa/libbwaindex.pxd
@@ -44,7 +44,6 @@ cdef extern from "bntseq.h":
     void bns_destroy(bntseq_t *bns)
 
 cdef bytes force_bytes(object s)
-cdef bytes force_bytes_with(object s, encoding: str | None = *, errors: str | None = *)
 cpdef bint _set_bwa_idx_verbosity(int level)
 
 cdef class BwaIndex:


### PR DESCRIPTION


<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--110.org.readthedocs.build/en/110/

<!-- readthedocs-preview pybwa end -->