### PR TITLE
chore(release): bump to 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pybwa"
-version = "2.2.0"
+version = "2.3.0"
 description = "Python bindings for BWA"
 readme = "README.md"
 authors = [{name = "Nils Homer", email = "nils@fulcrumgenomics.com"}]


### PR DESCRIPTION
## Summary
- Bump version from 2.2.0 to 2.3.0

## Changes since 2.2.0

### Features
- Drop Python 3.9, add Python 3.13 and 3.14 support (#120)
- Improve type hints for better IDE support (#119)
- Context manager support for `BwaAln` and `BwaMem` (#119)
- Cached SAM headers for improved performance (#119)

### Fixes
- Add error checking and safe pointer initialization in `BwaIndex`
- Add `sam_hdr_destroy` declaration to prevent double-free
- Correct typo in htslib configuration path
- Pre-compile bwa into static library to eliminate parallel build race condition (#119)
- Raw-string guard in `BwaAln.align()` to prevent character-by-character iteration (#119)
- Quality-length validation before memcpy in `BwaAln._copy_seq()` (#119)
- NULL check and exception-safe cleanup for `bwa_aln_and_samse` return (#119)
- Header use-after-free guard when calling `align()` after context manager exit (#119)

### Documentation
- Revamp README with quick start examples (#121)
- Improve docstrings across public API (#121)
- Reorganize api.rst with task-oriented "so you want to do X" examples (#121)
- Add thread-safety warning to `set_bwa_verbosity` (#119)

### Refactor/Infra
- Consolidate error checking with shared utility functions (#119)
- Add caching for htslib build artifacts (#119)
- Comprehensive error handling and resource management tests (#119)

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--122.org.readthedocs.build/en/122/

<!-- readthedocs-preview pybwa end -->