### PR TITLE
fix: honor $CC/$AR env vars when compiling the bwa static library

### DIFF
--- a/build.py
+++ b/build.py
@@ -142,8 +142,13 @@ def compile_bwa(
         logger.info("Using cached bwa static library...")
         return
 
-    cc = sysconfig.get_config_var("CC") or os.environ.get("CC", "gcc")
-    ar = sysconfig.get_config_var("AR") or os.environ.get("AR", "ar")
+    # Prefer the ``CC``/``AR`` environment variables over the values baked into
+    # ``sysconfig`` so that cross-compilation environments (e.g. conda-build, which
+    # exposes a prefixed compiler such as ``x86_64-conda-linux-gnu-gcc`` via ``$CC``
+    # and does not provide a bare ``gcc`` on ``PATH``) are honored. This mirrors how
+    # distutils/setuptools customize the compiler for the extension build itself.
+    cc = os.environ.get("CC") or sysconfig.get_config_var("CC") or "gcc"
+    ar = os.environ.get("AR") or sysconfig.get_config_var("AR") or "ar"
 
     cflags_parts = ["-fpic", "-g", "-Wall", "-O2"]
     if IS_DARWIN:


### PR DESCRIPTION
The static-library compile step added in 2.3.0 (`compile_bwa_static_library` in `build.py`) selected the compiler as `sysconfig.get_config_var("CC") or os.environ.get("CC", "gcc")`. Under conda-build, `sysconfig`'s `CC` is a bare `gcc` (a truthy value), so the `$CC` fallback was never reached — even though conda exposes its compiler only as `x86_64-conda-linux-gnu-gcc` via `$CC` and provides no bare `gcc` on `PATH`. The build therefore failed with `gcc: command not found`.

This is the root cause of the failing [bioconda-recipes #63146](https://github.com/bioconda/bioconda-recipes/pull/63146) (2.2.0 → 2.3.0 autobump), which fails on both Linux and ARM. 2.2.0 was unaffected because it predates the static-library step.

## Fix

Prefer the `$CC`/`$AR` environment variables over the `sysconfig` values, mirroring how setuptools/distutils customize the compiler for the Cython extension build itself. Normal (non-conda) installs are unaffected: with `$CC` unset the build falls back to the `sysconfig` compiler exactly as before.

## Verification

Local clean build with `CC` set in the environment (the conda code path) compiles `libbwa.a` and all four Cython extensions, and `import pybwa` succeeds.