### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/cibuildwheel/action.yaml
+++ b/.github/actions/cibuildwheel/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Build wheels
-      uses: pypa/cibuildwheel@v3.3.0
+      uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
       with:
         package-dir: .
         output-dir: wheelhouse

--- a/.github/workflows/publish_pybwa.yml
+++ b/.github/workflows/publish_pybwa.yml
@@ -20,7 +20,7 @@ jobs:
         shell: bash
         run: git config --global remote.origin.followRemoteHEAD never
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -29,7 +29,7 @@ jobs:
         shell: bash
         run: git branch -a
 
-      - uses: rickstaa/action-contains-tag@v1
+      - uses: rickstaa/action-contains-tag@a9ff27d505ba2bf074a2ebb48b208e76d35ff308 # v1
         id: contains_tag
         with:
           reference: "main"
@@ -53,12 +53,12 @@ jobs:
     needs: tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.12
 
@@ -87,7 +87,7 @@ jobs:
         run: poetry install --no-interaction --no-root --without=dev
 
       - name: Install pybwa
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           shell: bash
           max_attempts: 2
@@ -107,7 +107,7 @@ jobs:
       - name: Print contents
         run: tar -tf dist/*.tar.gz
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pybwa-sdist
           path: dist/*.tar.gz
@@ -119,13 +119,13 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: packages
           pattern: 'pybwa-*'
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: packages/
           skip-existing: true
@@ -138,14 +138,14 @@ jobs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout the Repository at the Tagged Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
           submodules: 'recursive'
 
       - name: Generate a Changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         id: git-cliff
         with:
           config: pyproject.toml
@@ -162,7 +162,7 @@ jobs:
     needs: make-changelog
     steps:
       - name: Download the sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: pybwa-sdist
       - name: Display structure of downloaded files
@@ -170,7 +170,7 @@ jobs:
         run: ls -R
       - name: Create Draft Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           name: ${{ github.ref_name }}
           body: ${{ needs.make-changelog.outputs.release_body }}

--- a/.github/workflows/readthedocs.yaml
+++ b/.github/workflows/readthedocs.yaml
@@ -11,6 +11,6 @@ jobs:
   documentation-links:
     runs-on: ubuntu-24.04
     steps:
-      - uses: readthedocs/actions/preview@v1
+      - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1
         with:
           project-slug: "pybwa"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,12 @@ jobs:
       matrix:
         PYTHON_VERSION: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: 'recursive'
 
     - name: Cache htslib build
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       id: htslib-cache
       with:
         path: |
@@ -38,7 +38,7 @@ jobs:
         key: htslib-${{ runner.os }}-${{ hashFiles('htslib/**/*.c', 'htslib/**/*.h', 'htslib/configure.ac', 'htslib/Makefile') }}
 
     - name: Set up Python ${{matrix.PYTHON_VERSION}}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{matrix.PYTHON_VERSION}}
 
@@ -71,7 +71,7 @@ jobs:
       run: poetry config virtualenvs.in-project true
 
     - name: Set up cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       id: cache
       with:
         path: .venv
@@ -92,7 +92,7 @@ jobs:
       run: poetry install --no-interaction --no-root
 
     - name: Install pybwa
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         shell: bash
         max_attempts: 2
@@ -134,6 +134,6 @@ jobs:
         poetry run make html
 
     - name: Upload code coverage
-      uses: codecov/codecov-action@v4.5.0
+      uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,12 +27,12 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: 'recursive'
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: 3.12
 
@@ -84,7 +84,7 @@ jobs:
             python-version: cp314
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: 'recursive'
 
@@ -92,7 +92,7 @@ jobs:
       # will build natively without emulation, which is significantly faster for ARM builds.
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Build wheels
         uses: ./.github/actions/cibuildwheel
@@ -126,7 +126,7 @@ jobs:
               exit 1
             fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pybwa-${{needs.define-pybwa-version.outputs.version}}-${{ matrix.python-version }}-${{ matrix.buildplat[1] }}.whl
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
Pin every third-party GitHub Actions reference to its full 40-character commit SHA, keeping the previous tag as a trailing version comment (e.g. `actions/checkout@34e1148... # v4`).

This is required by bioconda's linter (which flags unpinned actions) and is the recommended hardening against tag-mutation supply-chain attacks, where a mutable tag like `@v4` can be repointed to malicious code.

In-repo references — the reusable workflows (`./.github/workflows/*.yml`) and the local `cibuildwheel` composite action (`./.github/actions/cibuildwheel`) — are intentionally left as path references.

## Actions pinned

| Action | Tag |
|---|---|
| `actions/checkout` | v4 |
| `actions/setup-python` | v5 |
| `actions/cache` | v4 |
| `actions/upload-artifact` | v4 |
| `actions/download-artifact` | v4 |
| `rickstaa/action-contains-tag` | v1 |
| `nick-fields/retry` | v3 |
| `codecov/codecov-action` | v4.5.0 |
| `docker/setup-qemu-action` | v3 |
| `pypa/gh-action-pypi-publish` | release/v1 |
| `pypa/cibuildwheel` | v3.3.0 |
| `orhun/git-cliff-action` | v4 |
| `softprops/action-gh-release` | v2 |
| `readthedocs/actions/preview` | v1 |