### PR TITLE
chore(release): bump to 2.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pybwa"
-version = "2.3.0"
+version = "2.3.1"
 description = "Python bindings for BWA"
 readme = "README.md"
 authors = [{name = "Nils Homer", email = "nils@fulcrumgenomics.com"}]


### PR DESCRIPTION
Patch release bumping `2.3.0` → `2.3.1`.

Carries the conda-build fix from #124 (honor `$CC`/`$AR` when compiling the bwa static library), which unblocks the [bioconda 2.3.0 → 2.x autobump](https://github.com/bioconda/bioconda-recipes/pull/63146).

**Merge order:** merge #124 first, then this PR, then tag `2.3.1` on `main` to trigger the publish workflow.