### PR TITLE
fix: honor $CPPFLAGS and $CFLAGS when compiling bwa and htslib

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sysconfig
@@ -75,6 +76,19 @@ USE_GIT: bool = shutil.which("git") is not None and Path(".git").exists() and Pa
 IS_DARWIN = platform.system() == "Darwin"
 
 
+def env_flags(*names: str) -> list[str]:
+    """
+    Returns the flags set in the given environment variables, in the order given.
+
+    ``CPPFLAGS`` and ``CFLAGS`` describe the include paths and code generation options of the
+    active toolchain. Notably, conda-build exposes ``-isystem $PREFIX/include`` via ``CPPFLAGS``,
+    which is the only way to locate headers such as ``zlib.h`` when building against a relocated
+    prefix. ``setuptools`` applies these automatically when compiling the extension modules, so
+    they must be applied by hand wherever this script invokes the compiler itself.
+    """
+    return [flag for name in names for flag in shlex.split(os.environ.get(name, ""))]
+
+
 def run_command(command: str, fail_on_error: bool = True) -> int:
     """Runs a given command, return the return code or failing on error if desired."""
     retcode = subprocess.call(
@@ -89,10 +103,13 @@ def run_command(command: str, fail_on_error: bool = True) -> int:
 def compile_htslib(logger: logging.Logger) -> None:
     """Complies htslib prior to entering the context."""
     with changedir("htslib"):
-        cflags = "CFLAGS='-fpic -fvisibility=hidden -g -Wall -O2"
+        cflags_parts = ["-fpic", "-fvisibility=hidden", "-g", "-Wall", "-O2"]
         if IS_DARWIN:
-            cflags += " -mmacosx-version-min=11.0"
-        cflags += "'"
+            cflags_parts.append("-mmacosx-version-min=11.0")
+        # ``configure`` inherits ``CPPFLAGS`` from the environment on its own, but setting
+        # ``CFLAGS`` on the command line overrides the environment's value, so merge it back in.
+        cflags_parts.extend(env_flags("CFLAGS"))
+        cflags = "CFLAGS=" + shlex.quote(" ".join(cflags_parts))
 
         # Check if already built (e.g., from cache)
         if Path("libhts.a").exists() and Path("config.h").exists():
@@ -157,6 +174,9 @@ def compile_bwa(
         cflags_parts.append(f"-D{name}" if value is None else f"-D{name}={value}")
     for d in include_dirs:
         cflags_parts.append(f"-I{d}")
+    # Added after the vendored include directories so those still take precedence, but before
+    # ``compile_args`` so its ``-Wno-*`` suppressions still win over any warnings enabled here.
+    cflags_parts.extend(env_flags("CPPFLAGS", "CFLAGS"))
     cflags_parts.extend(compile_args)
     cflags = " ".join(cflags_parts)
 


### PR DESCRIPTION
Fixes building the sdist under conda-build, which currently fails with:

```
bwa/bntseq.h:34:10: fatal error: zlib.h: No such file or directory
```

## Cause

`compile_bwa()` (added in 2.3.0, to pre-compile bwa into a static library and avoid a parallel build race) constructs its compiler flags from scratch and never consults the environment. conda-build exposes `$PREFIX/include` solely through `$CPPFLAGS`, so headers that live only in the prefix — `zlib.h` among them — are invisible to it.

This is a regression from 2.2.0, where those same `bwa/*.c` sources were compiled by setuptools `build_ext`, which applies `$CPPFLAGS` and `$CFLAGS` automatically. The extension modules still build correctly today for exactly that reason; only the hand-rolled static-library step is affected.

`compile_htslib()` has the same class of bug: passing `CFLAGS` on the `configure` command line overrides the environment value rather than extending it, silently dropping the toolchain code generation flags. It kept working only because `configure` inherits `$CPPFLAGS` on its own.

## Change

Adds `env_flags()` and merges the environment flags back in for both steps. In `compile_bwa()` they are appended after the vendored `-I` directories, so those still take precedence, but before `compile_args`, so its `-Wno-*` suppressions still win.

## Verification

Built the 2.3.1 sdist with this patch applied through `bioconda-utils` in the real bioconda build container (`bioconda-utils-build-env-cos7-aarch64:4.4.1`) — the same path that fails on bioconda-recipes#63146:

```
BUILD SUMMARY: successfully built 1 of 1 recipes
```

All four Python variants (3.10–3.13) compiled `bwa/libbwa.a`, packaged, and passed their import tests, with no `zlib.h` error.

Unblocks bioconda-recipes#63146.