### PR TITLE
ci: post the docs preview link without an unpinnable action

### DIFF
--- a/.github/workflows/readthedocs.yaml
+++ b/.github/workflows/readthedocs.yaml
@@ -11,6 +11,20 @@ jobs:
   documentation-links:
     runs-on: ubuntu-24.04
     steps:
-      - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1
-        with:
-          project-slug: "pybwa"
+      # This deliberately does not use ``readthedocs/actions/preview``. That composite action
+      # internally references ``actions/checkout@v3`` and ``actions/github-script@v6``, neither of
+      # which is pinned to a full-length commit SHA, so the organization's action-pinning policy
+      # rejects the job during setup before any step runs. Posting the link with the ``gh`` CLI
+      # keeps this job green without taking on a new action to pin and track.
+      - name: Comment with the documentation preview link
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PROJECT_SLUG: pybwa
+        run: |
+          set -euo pipefail
+          preview_url="https://${PROJECT_SLUG}--${PR_NUMBER}.org.readthedocs.build/en/${PR_NUMBER}/"
+          gh pr comment "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "📖 Documentation preview: ${preview_url}"


### PR DESCRIPTION
The `documentation-links` job has failed on every pull request since the organization began requiring all actions to be pinned to a full-length commit SHA:

| result | branch |
|--------|--------|
| failure | `nh_honor-env-cflags` |
| failure | `nh_release-2.3.1` |
| failure | `nh_pin-actions-to-sha` ← policy introduced here |
| failure | `nh_fix-conda-cc-precedence` |
| success | `doc/nh_add-fulcrum-logo` ← last green, pre-policy |

It fails during job setup, before a single step runs:

```
The actions actions/checkout@v3 and actions/github-script@v6 are not allowed in
fulcrumgenomics/pybwa because all actions must be pinned to a full-length commit SHA.
```

The workflow already pins `readthedocs/actions/preview` correctly. The offending references live *inside* that composite action, so nothing we pin on our end can satisfy the policy — the action would have to fix its own pins upstream.

## Change

Post the preview link with the `gh` CLI instead. This introduces no new action to pin and track, and needs no checkout.

## Verification

`actionlint` passes. Confirmed the Read the Docs preview URL scheme resolves — the constructed links for recent pull requests both return HTTP 200:

```
200  https://pybwa--126.org.readthedocs.build/en/126/
200  https://pybwa--125.org.readthedocs.build/en/125/
```

Since the workflow triggers on `pull_request_target`, the fixed job will not run on this pull request itself — it takes effect on the next one opened after merge.