### PR TITLE
ci: also post the docs preview link when a pull request is reopened

### DIFF
--- a/.github/workflows/readthedocs.yaml
+++ b/.github/workflows/readthedocs.yaml
@@ -3,6 +3,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - reopened
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Follow-up to #128.

A reopened pull request is back in review and wants its documentation preview link just as much as a freshly opened one, but the job only triggered on `opened`, so reopening left the link behind on the closed timeline.

Adding `reopened` also makes the job reachable for verification. With only `opened`, a change to this workflow can never be exercised on an existing pull request, because `pull_request_target` always runs the *base branch* definition — which is exactly why #128 could not go green on itself.

## Verification

This pull request is itself the end-to-end test of #128: it fires `opened`, and `pull_request_target` now resolves the workflow from `main`, which carries the merged `gh`-CLI implementation. If the `documentation-links` check is green here and a preview-link comment appears below, #128 is confirmed working on a real runner.