### PR TITLE
chore(release): bump to 2.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pybwa"
-version = "2.3.1"
+version = "2.3.2"
 description = "Python bindings for BWA"
 readme = "README.md"
 authors = [{name = "Nils Homer", email = "nils@fulcrumgenomics.com"}]


### PR DESCRIPTION
Patch release for the conda-build fix in #127.

`compile_bwa()` never consulted `$CPPFLAGS`, so building the sdist under conda-build failed to find headers that live only in the prefix:

```
bwa/bntseq.h:34:10: fatal error: zlib.h: No such file or directory
```

This blocks bioconda-recipes#63146, which cannot be updated to any 2.3.x until a release carries the fix.

## Contents

- #127 — `fix:` honor `$CPPFLAGS` and `$CFLAGS` when compiling bwa and htslib
- #128 — `ci:` post the docs preview link without an unpinnable action
- #129 — `ci:` also post the docs preview link when a pull request is reopened